### PR TITLE
chore: bump node runtime version to node 16

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -31,5 +31,5 @@ inputs:
     required: false
 
 runs:
-  using: node12
+  using: node16
   main: dist/index.js


### PR DESCRIPTION
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12

![CleanShot 2022-10-11 at 10 04 23](https://user-images.githubusercontent.com/22584594/194974934-0e77f6ac-529b-490e-9cc0-2f94e6f8706c.png)
